### PR TITLE
Refactor to start using the simplest imgui_ctx context managers

### DIFF
--- a/pyMRI/gui/menu/colouring.py
+++ b/pyMRI/gui/menu/colouring.py
@@ -27,13 +27,13 @@ class ColouringTab(GuiTab):
         if self._data_histogram is None:
             self._data_histogram = np.array([1.0], dtype=np.float32) #self._renderer.get_histogram()
 
-        imgui.push_item_width(-1)
-        x, _ = imgui.get_content_region_avail()
-        imgui.plot_histogram(
-            "##histogram",
-            self._data_histogram,
-            graph_size=(x, 80)
-        )
-        imgui.pop_item_width()
+        with imgui_ctx.push_item_width(-1):
+            x, _ = imgui.get_content_region_avail()
+            imgui.plot_histogram(
+                "##histogram",
+                self._data_histogram,
+                graph_size=(x, 80)
+            )
+
         _, self._renderer.density_scalar = imgui.slider_float("Density Scalar", self._renderer.density_scalar, 0.001, 1.0)
         _, self._renderer.emission_brightness = imgui.slider_float("Emission Brightness", self._renderer.emission_brightness, 0.001, 1.0)

--- a/pyMRI/gui/menu/load.py
+++ b/pyMRI/gui/menu/load.py
@@ -1,4 +1,4 @@
-from imgui_bundle import imgui
+from imgui_bundle import imgui, imgui_ctx
 
 from pyMRI.gui.menu.tab import GuiTab
 from pyMRI.processing import Unit, ORIENTATIONS, FILE_LOADER_STEP
@@ -12,13 +12,14 @@ class LoadingTab(GuiTab):
     def update(self):
         imgui.text("Data File:")
         x, _ = imgui.get_content_region_avail()
-        imgui.push_item_width(x - 80.0)
-        load_data, path = imgui.input_text(
-            "##data file",
-            FILE_LOADER_STEP.data_path or "",
-            imgui.InputTextFlags_.enter_returns_true,
-        )
-        imgui.pop_item_width()
+
+        with imgui_ctx.push_item_width(x - 80.0):
+            load_data, path = imgui.input_text(
+                "##data file",
+                FILE_LOADER_STEP.data_path or "",
+                imgui.InputTextFlags_.enter_returns_true,
+            )
+
         imgui.same_line()
         browse_data = imgui.button("browse##data", (70.0, 0.0))
 
@@ -48,13 +49,13 @@ class LoadingTab(GuiTab):
             # Parameter File: [file loc] {browse button}
             imgui.text("Parameter File:")
             x, _ = imgui.get_content_region_avail()
-            imgui.push_item_width(x - 80.0)
-            load_para, path = imgui.input_text(
-                "##parameter file",
-                FILE_LOADER_STEP.parameter_path or "",
-                imgui.InputTextFlags_.enter_returns_true,
-            )
-            imgui.pop_item_width()
+            with imgui_ctx.push_item_width(x - 80.0):
+                load_para, path = imgui.input_text(
+                    "##parameter file",
+                    FILE_LOADER_STEP.parameter_path or "",
+                    imgui.InputTextFlags_.enter_returns_true,
+                )
+
             imgui.same_line()
             browse_para = imgui.button("browse##para", (70.0, 0.0))
 

--- a/pyMRI/gui/menu/menu.py
+++ b/pyMRI/gui/menu/menu.py
@@ -1,4 +1,4 @@
-from imgui_bundle import imgui
+from imgui_bundle import imgui. imgui_ctx
 
 from arcade import get_window
 
@@ -64,11 +64,10 @@ class GuiMenu:
         imgui.set_next_window_bg_alpha(0.35)
 
         imgui.begin("Control Panel", False, win_flags)
-        if imgui.begin_tab_bar("#tabs"):
+        with imgui_ctx.begin_tab_bar("#tabs"):
             for tab in self._tabs:
                 selected, *_ = imgui.begin_tab_item(tab.title)
                 if selected:
                     tab.update()
                     imgui.end_tab_item()
-            imgui.end_tab_bar()
         imgui.end()

--- a/pyMRI/gui/menu/transform.py
+++ b/pyMRI/gui/menu/transform.py
@@ -10,7 +10,7 @@ from pyMRI.processing import (
     FourierNorm,
 )
 
-from imgui_bundle import imgui
+from imgui_bundle import imgui, imgui_ctx
 
 
 class TransformTab(GuiTab):
@@ -34,13 +34,13 @@ class TransformTab(GuiTab):
         )
         imgui.text("pre transform: ")
         imgui.same_line()
-        imgui.push_item_width(slider_width)
-        cx, x = imgui.slider_int("##pre-shift-x", PRE_SHIFT_STEP.shifts[0], -sx, sx)
-        imgui.same_line()
-        cy, y = imgui.slider_int("##pre-shift-y", PRE_SHIFT_STEP.shifts[1], -sy, sy)
-        imgui.same_line()
-        cz, z = imgui.slider_int("##pre-shift-z", PRE_SHIFT_STEP.shifts[2], -sz, sz)
-        imgui.pop_item_width()
+        with imgui_ctx.push_item_width(slider_width):
+            cx, x = imgui.slider_int("##pre-shift-x", PRE_SHIFT_STEP.shifts[0], -sx, sx)
+            imgui.same_line()
+            cy, y = imgui.slider_int("##pre-shift-y", PRE_SHIFT_STEP.shifts[1], -sy, sy)
+            imgui.same_line()
+            cz, z = imgui.slider_int("##pre-shift-z", PRE_SHIFT_STEP.shifts[2], -sz, sz)
+
         if cx or cy or cz:
             PRE_SHIFT_STEP.shifts = (x, y, z)
             if self.pair_shifts:
@@ -50,14 +50,14 @@ class TransformTab(GuiTab):
             imgui.begin_disabled()
 
         imgui.text("post transform:")
-        imgui.push_item_width(slider_width)
-        imgui.same_line()
-        cx, x = imgui.slider_int("##post-shift-x", POST_SHIFT_STEP.shifts[0], -sx, sx)
-        imgui.same_line()
-        cy, y = imgui.slider_int("##post-shift-y", POST_SHIFT_STEP.shifts[1], -sy, sy)
-        imgui.same_line()
-        cz, z = imgui.slider_int("##post-shift-z", POST_SHIFT_STEP.shifts[2], -sz, sz)
-        imgui.pop_item_width()
+        with imgui_ctx.push_item_width(slider_width):
+            imgui.same_line()
+            cx, x = imgui.slider_int("##post-shift-x", POST_SHIFT_STEP.shifts[0], -sx, sx)
+            imgui.same_line()
+            cy, y = imgui.slider_int("##post-shift-y", POST_SHIFT_STEP.shifts[1], -sy, sy)
+            imgui.same_line()
+            cz, z = imgui.slider_int("##post-shift-z", POST_SHIFT_STEP.shifts[2], -sz, sz)
+
         if cx or cy or cz:
             POST_SHIFT_STEP.shifts = (x, y, z)
 

--- a/pyMRI/gui/popups/popup.py
+++ b/pyMRI/gui/popups/popup.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 from arcade import get_window
 
-from imgui_bundle import imgui
+from imgui_bundle import imgui. imgui_ctx
 
 
 class WarningMode(Enum):
@@ -70,9 +70,8 @@ class GuiPopup:
         imgui.set_next_window_bg_alpha(0.35)
 
         imgui.begin(self._title, False, POPUP_FLAGS)
-        imgui.push_style_color(COLOR_TEXT_FLAG, self._colour)
-        imgui.text(self._title)
-        imgui.pop_style_color()
+        with imgui_ctx.push_style_color(COLOR_TEXT_FLAG, self._colour):
+            imgui.text(self._title)
 
         self.build_body()
         self.build_buttons()


### PR DESCRIPTION
**TL;DR:** Use the least complicated features from [`imgui_bundle.imgui_ctx`'s](https://github.com/pthom/imgui_bundle/blob/main/bindings/imgui_bundle/imgui_ctx.py) to reduce the risk of breaking things

### Changes

Use the simplest context managers in the module to reduce risk of unclosed widget scopes. This is split from the things listed in the follow-up work heading below.

No tests for this at the moment since:
1. No tests exist for it currently
2. I'm not yet sure what the best way to go about injecting those events is
   * This is a larger pyglet / Arcade problem
   * PyAutoGUI has gotchas

### Follow-up Work

1. Finish prototyping syntax sugar / helpers for the more complex context managers:
2. Explore composability / spacer POD classes to help with row declaration
3. Write more tests before PR